### PR TITLE
Convert Solr's leader string to bool for replica metadata and descending sort by pod ordinal if leader count matches

### DIFF
--- a/controllers/util/solr_api/cluster_status.go
+++ b/controllers/util/solr_api/cluster_status.go
@@ -118,7 +118,7 @@ type SolrReplicaStatus struct {
 
 	BaseUrl string `json:"base_url"`
 
-	Leader bool `json:"leader"`
+	Leader bool `json:"leader,string"`
 
 	// +optional
 	Type SolrReplicaType `json:"type"`

--- a/controllers/util/upgrade_util.go
+++ b/controllers/util/upgrade_util.go
@@ -160,7 +160,15 @@ func sortNodePodsBySafety(outOfDatePods []corev1.Pod, nodeMap map[string]SolrNod
 		} else if nodeJ.overseerLeader {
 			return true
 		}
-		return nodeI.leaders < nodeJ.leaders
+
+		if nodeI.leaders == nodeJ.leaders {
+			if nodeI.nodeName < nodeJ.nodeName {
+				return false // sort largest ordinal first
+			}
+			return true
+		} else {
+			return nodeI.leaders < nodeJ.leaders
+		}
 	})
 }
 

--- a/controllers/util/upgrade_util_test.go
+++ b/controllers/util/upgrade_util_test.go
@@ -108,7 +108,7 @@ func TestPickPodsToUpgrade(t *testing.T) {
 
 	// Normal inputs
 	podsToUpgrade = getPodNames(pickPodsToUpgrade(solrCloud, halfPods, testHealthyClusterStatus, overseerLeader, 6, 1, 0))
-	assert.ElementsMatch(t, []string{"pod-1"}, podsToUpgrade, "Incorrect set of next pods to upgrade. Do to replica placement, only the node with the least leaders can be upgraded.")
+	assert.ElementsMatch(t, []string{"pod-5"}, podsToUpgrade, "Incorrect set of next pods to upgrade. Do to replica placement, only the node with the least leaders can be upgraded.")
 
 	// Test the maxShardReplicasDownSpec
 	podsToUpgrade = getPodNames(pickPodsToUpgrade(solrCloud, halfPods, testHealthyClusterStatus, overseerLeader, 6, 2, 0))
@@ -202,7 +202,7 @@ func TestPodUpgradeOrdering(t *testing.T) {
 		},
 	}
 
-	expectedOrdering := []string{"pod-2", "pod-3", "pod-5", "pod-1", "pod-4", "pod-0"}
+	expectedOrdering := []string{"pod-2", "pod-5", "pod-3", "pod-1", "pod-4", "pod-0"}
 
 	sortNodePodsBySafety(pods, nodeMap, solrCloud)
 	foundOrdering := make([]string, len(pods))


### PR DESCRIPTION
Convert Solr's leader string to bool for replica metadata and descending sort by pod ordinal if leader count matches

Signed-off-by: Timothy Potter <thelabdude@gmail.com>